### PR TITLE
Bump okhttp3-version from 3.14.3 to 4.8.0

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -224,7 +224,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.6.2</swagger-core-version>
     <sundrio.version>0.21.0</sundrio.version>
-    <okhttp3-version>3.14.3</okhttp3-version>
+    <okhttp3-version>4.8.0</okhttp3-version>
     <gson-version>2.8.6</gson-version>
     <gsonfire-version>1.8.4</gsonfire-version>
     <jodatime-version>2.10.6</jodatime-version>


### PR DESCRIPTION
Bumps `okhttp3-version` from 3.14.3 to 4.8.0.

Updates `okhttp` from 3.14.3 to 4.8.0
- [Release notes](https://github.com/square/okhttp/releases)
- [Changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md)
- [Commits](https://github.com/square/okhttp/compare/parent-3.14.3...parent-4.8.0)

Updates `logging-interceptor` from 3.14.3 to 4.8.0
- [Release notes](https://github.com/square/okhttp/releases)
- [Changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md)
- [Commits](https://github.com/square/okhttp/compare/parent-3.14.3...parent-4.8.0)

Signed-off-by: dependabot[bot] <support@github.com>