### PR TITLE
docs: append software delivery poem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-> *Ship it fast, ship it true — every build a rendezvous.*
+> *Ship it fast, ship it true; every build sees the journey through.*

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+> *Ship it fast, ship it true — every build a rendezvous.*


### PR DESCRIPTION
## Summary

- Appends a single original one-line poem about software delivery to the end of `README.md`.

## Change

Added the line:

> *Ship it fast, ship it true — every build a rendezvous.*

## Test plan

- [ ] Verify the new line appears at the bottom of the rendered README on GitHub.
- [ ] Confirm no existing content was modified.