### PR TITLE
docs: add software delivery poem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+<!-- From commit to cluster, code takes flight; each pipeline a promise kept in the night. -->


### PR DESCRIPTION
## Summary

- Appends a single original one-line poem about software delivery to the end of `README.md`.
- The poem reads: *"From commit to cluster, code takes flight; each pipeline a promise kept in the night."*
- No functional or structural changes to the document — purely additive.

## Test plan

- [ ] Verify the new line appears at the bottom of `README.md` on the branch.
- [ ] Confirm no existing content was altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)