### PR TITLE
Add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+> *Ship early, ship often — each deploy a small brave step from thought to living code.*


### PR DESCRIPTION
## Summary

Appends a single original one-line poem about software delivery to the end of `README.md`:

> *Ship early, ship often — each deploy a small brave step from thought to living code.*

## Changes

- `README.md`: one new line added at the end of the file.

## Test plan

- [ ] Confirm the poem line appears correctly at the bottom of the rendered README on GitHub.
- [ ] Verify no existing content was altered.