### PR TITLE
docs: add one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+Code takes flight through pipelines bright, delivered safe by dawn's first light.


### PR DESCRIPTION
## Summary

Appends a single original one-line poem about software delivery to the end of `README.md`:

> *Code takes flight through pipelines bright, delivered safe by dawn's first light.*

## Changes

- `README.md`: one new line appended at the end of the file

## Test plan

- [ ] Verify the new line appears at the bottom of `README.md` on the branch
- [ ] Confirm no existing content was modified