### PR TITLE
Add software delivery poem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+> *Ship it green, ship it fast — every pipeline a bridge from code to hands at last.*


### PR DESCRIPTION
## Summary

- Appends a single original one-line poem about software delivery to the end of `README.md`.

## Change

> *Ship it green, ship it fast — every pipeline a bridge from code to hands at last.*

## Test plan

- [ ] Confirm the new line appears at the bottom of `README.md` on the branch.
- [ ] Verify no other content was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)