### PR TITLE
docs: add one-line software delivery poem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+> *Code ships at dawn, pipelines hum through the night — each commit a quiet promise that everything will be alright.*


### PR DESCRIPTION
## Summary

Appends a single original poem line to the end of `README.md` celebrating software delivery:

> *Code ships at dawn, pipelines hum through the night — each commit a quiet promise that everything will be alright.*

## Changes
- `README.md`: one new line added at the end of the file

## Test plan
- [ ] Verify the poem line appears correctly at the bottom of the rendered README on GitHub
- [ ] Confirm no existing content was modified