### PR TITLE
docs: add one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+> *Ship it fast, ship it right — each pipeline a promise kept in flight.*

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-> *Ship it fast, ship it right — each pipeline a promise kept in flight.*
+> *Ship it fast, ship it right — each pipeline a promise carried to light.*


### PR DESCRIPTION
## Summary

Appends a single original poem line to the end of `README.md` celebrating the spirit of software delivery:

> *Ship it fast, ship it right — each pipeline a promise kept in flight.*

## Changes

- `README.md`: one new line added at the end of the file — no existing content modified.

## Test plan

- [ ] Verify the new line appears at the bottom of the rendered README on GitHub.
- [ ] Confirm no existing content was altered by reviewing the diff.