### PR TITLE
Add memoized Fibonacci utility

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,48 @@
+# Design: Fibonacci Utility
+
+## Goal
+
+Add a small, self-contained utility class that computes Fibonacci numbers,
+using memoization so repeated/large lookups don't re-do exponential work.
+
+## Location
+
+`util/src/main/java/io/kubernetes/client/util/Fibonacci.java`, in the
+existing `util` module alongside other stateless helpers (e.g.
+`PatchUtils`, `SSLUtils`). No new module or dependency is needed.
+
+## API
+
+```java
+public final class Fibonacci {
+  public static long compute(int n);
+}
+```
+
+- `compute(n)` returns the `n`-th Fibonacci number (0-indexed: `F(0)=0`,
+  `F(1)=1`).
+- Throws `IllegalArgumentException` for `n < 0`.
+- `long` is used as the return type since Fibonacci values grow quickly
+  (values beyond `n=92` overflow `long`, which is an accepted, documented
+  limitation rather than something this utility needs to solve).
+
+## Memoization approach
+
+Results are cached in a `Map<Integer, Long>` (`ConcurrentHashMap`) keyed by
+`n`. `compute(n)` looks up the cache first; on a miss it computes
+iteratively from the closest previously-cached value (or from 0) and
+stores every intermediate result along the way, so subsequent calls for
+any smaller or equal `n` are O(1).
+
+An iterative fill (rather than recursive memoization) avoids stack depth
+concerns for large `n` and keeps the cache-population logic simple and
+thread-safe via `ConcurrentHashMap`.
+
+## Testing
+
+A JUnit 4 test class `FibonacciTest` (matching the module's existing test
+conventions) covers:
+- Base cases (`F(0)`, `F(1)`).
+- A handful of known values.
+- Repeated calls returning consistent cached results.
+- `n < 0` throwing `IllegalArgumentException`.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,20 @@
+# Plan: Fibonacci Utility
+
+See `docs/design.md` for the approach. Implementation breaks into 3 tasks:
+
+## Task 1 — Implement `Fibonacci` class
+
+Add `util/src/main/java/io/kubernetes/client/util/Fibonacci.java` with a
+`compute(int n)` static method backed by a `ConcurrentHashMap` memo cache,
+per the design doc. Validate `n >= 0`.
+
+## Task 2 — Unit tests
+
+Add `util/src/test/java/io/kubernetes/client/util/FibonacciTest.java`
+covering base cases, known values, cache-consistency across repeated
+calls, and the negative-input error case.
+
+## Task 3 — Verify and open PR
+
+Build/test the `util` module, then open a pull request with the design
+doc, plan doc, class, and test.

--- a/util/src/main/java/io/kubernetes/client/util/Fibonacci.java
+++ b/util/src/main/java/io/kubernetes/client/util/Fibonacci.java
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/** Utility for computing Fibonacci numbers with memoization. */
+public final class Fibonacci {
+
+  private static final ConcurrentMap<Integer, Long> CACHE = new ConcurrentHashMap<>();
+
+  static {
+    CACHE.put(0, 0L);
+    CACHE.put(1, 1L);
+  }
+
+  private Fibonacci() {}
+
+  /**
+   * Returns the n-th Fibonacci number (0-indexed: compute(0) == 0, compute(1) == 1).
+   *
+   * @throws IllegalArgumentException if n is negative
+   */
+  public static long compute(int n) {
+    if (n < 0) {
+      throw new IllegalArgumentException("n must be >= 0, got: " + n);
+    }
+    Long cached = CACHE.get(n);
+    if (cached != null) {
+      return cached;
+    }
+    int start = n;
+    while (!CACHE.containsKey(start)) {
+      start--;
+    }
+    long prev = CACHE.get(start);
+    long prevPrev = CACHE.get(start - 1);
+    for (int i = start + 1; i <= n; i++) {
+      long value = prev + prevPrev;
+      CACHE.put(i, value);
+      prevPrev = prev;
+      prev = value;
+    }
+    return CACHE.get(n);
+  }
+}

--- a/util/src/test/java/io/kubernetes/client/util/FibonacciTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/FibonacciTest.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class FibonacciTest {
+
+  @Test
+  public void baseCasesShouldMatchDefinition() {
+    assertEquals(0, Fibonacci.compute(0));
+    assertEquals(1, Fibonacci.compute(1));
+  }
+
+  @Test
+  public void knownValuesShouldBeCorrect() {
+    assertEquals(1, Fibonacci.compute(2));
+    assertEquals(2, Fibonacci.compute(3));
+    assertEquals(5, Fibonacci.compute(5));
+    assertEquals(55, Fibonacci.compute(10));
+    assertEquals(6765, Fibonacci.compute(20));
+  }
+
+  @Test
+  public void repeatedCallsShouldReturnConsistentResults() {
+    long first = Fibonacci.compute(30);
+    long second = Fibonacci.compute(30);
+    assertEquals(first, second);
+    assertEquals(832040, first);
+  }
+
+  @Test
+  public void negativeInputShouldThrow() {
+    try {
+      Fibonacci.compute(-1);
+      fail("expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `Fibonacci.compute(n)` to the `util` module, memoized via a `ConcurrentHashMap` so repeated/incremental lookups are O(1) after the first fill.
- Adds `FibonacciTest` (JUnit 4) covering base cases, known values, cache consistency across repeated calls, and negative-input validation.
- Adds `docs/design.md` (approach/API) and `docs/plan.md` (3-task breakdown: implement class, unit tests, verify & PR).

## Note
This sandbox has no Java toolchain available, so `mvn test` could not be run here. The memoization logic was traced by hand against F(0)–F(3) and generalizes by induction; please run `./mvnw -pl util -am test -Dtest=FibonacciTest` in CI/locally to confirm before merging.

## Test plan
- [ ] `./mvnw -pl util -am test -Dtest=FibonacciTest`
