### PR TITLE
docs: add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-From commit to cloud, small code climbs quietly into a running world.
+From commit to cloud, small code grows into a running world.

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+From commit to cloud, small code climbs quietly into a running world.


### PR DESCRIPTION
## Summary
- Appends a single original one-line poem about software delivery to the end of README.md.

## Test plan
- N/A — documentation-only change; verified the line was appended correctly via the GitHub API response.