### PR TITLE
docs: add implementation plan for improving the README

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -2,9 +2,9 @@
 
 A short implementation plan for making the README more useful to new contributors and users.
 
-- **Add a Quickstart section**: a minimal end-to-end snippet (install → configure client → make one API call) above the detailed examples, so new users can get something running in under a minute.
-- **Reorganize examples by task, not by API area**: group links under user goals (e.g. "Connect to a cluster", "Watch resources", "Run in-cluster") to reduce time-to-find.
-- **Refresh the compatibility table**: automate or script generation of the client/Kubernetes version matrix so it doesn't drift out of date with each release.
-- **Add badges for build, license, and latest release**: give at-a-glance project health signals at the top of the file.
-- **Link a CONTRIBUTING quick-reference**: summarize the top 3-4 contribution steps inline, with a link to the full CONTRIBUTING.md for details.
-- **Add a Troubleshooting/FAQ section**: capture recurring setup issues (e.g. kubeconfig discovery, TLS errors) to reduce duplicate support questions.
+- **Add a Quickstart section** *(Impact: High, Effort: Low)*: a minimal end-to-end snippet (install → configure client → make one API call) above the detailed examples, so new users can get something running in under a minute.
+- **Reorganize examples by task, not by API area** *(Impact: Medium, Effort: Medium)*: group links under user goals (e.g. "Connect to a cluster", "Watch resources", "Run in-cluster") to reduce time-to-find.
+- **Refresh the compatibility table** *(Impact: Medium, Effort: High)*: automate or script generation of the client/Kubernetes version matrix so it doesn't drift out of date with each release. The table currently lives by hand in the README's Compatibility section and would need a generator script wired into the release process.
+- **Add badges for build, license, and latest release** *(Impact: Low, Effort: Low)*: give at-a-glance project health signals at the top of the file.
+- **Link a CONTRIBUTING quick-reference** *(Impact: Medium, Effort: Low)*: summarize the top 3-4 contribution steps inline, with a link to the full CONTRIBUTING.md for details.
+- **Add a Troubleshooting/FAQ section** *(Impact: High, Effort: Medium)*: capture recurring setup issues (e.g. kubeconfig discovery, TLS errors) to reduce duplicate support questions. This content doesn't exist anywhere in the repo yet and would need to be authored from scratch, likely sourced from past issue threads.

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,10 @@
+# Plan: Improve Project README
+
+A short implementation plan for making the README more useful to new contributors and users.
+
+- **Add a Quickstart section**: a minimal end-to-end snippet (install → configure client → make one API call) above the detailed examples, so new users can get something running in under a minute.
+- **Reorganize examples by task, not by API area**: group links under user goals (e.g. "Connect to a cluster", "Watch resources", "Run in-cluster") to reduce time-to-find.
+- **Refresh the compatibility table**: automate or script generation of the client/Kubernetes version matrix so it doesn't drift out of date with each release.
+- **Add badges for build, license, and latest release**: give at-a-glance project health signals at the top of the file.
+- **Link a CONTRIBUTING quick-reference**: summarize the top 3-4 contribution steps inline, with a link to the full CONTRIBUTING.md for details.
+- **Add a Troubleshooting/FAQ section**: capture recurring setup issues (e.g. kubeconfig discovery, TLS errors) to reduce duplicate support questions.


### PR DESCRIPTION
## Summary
- Adds `Plan.md`, a short original implementation plan with a few bullet points outlining concrete ways to improve the project's README (quickstart section, task-oriented example grouping, automated compatibility table, badges, contributing quick-reference, troubleshooting/FAQ).

## Test plan
- N/A — documentation-only change, no code affected.