### PR TITLE
docs: add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-Small commits flow like water, patient builds become the river to release.
+Small commits flow like a stream, patient builds carve the river to release.

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Small commits flow like water, patient builds become the river to release.


### PR DESCRIPTION
## Summary
- Appends a single original one-line poem about software delivery to the end of `README.md`.

## Why
A small, low-risk documentation touch to add a bit of personality to the README.

## Test plan
- [x] Confirmed the appended line renders correctly as plain Markdown text at the end of the file.