### PR TITLE
Add implementation plan for improving README

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -1,7 +1,9 @@
 # README Improvement Plan
 
-- Add a top-level "Quick Start" section with a minimal copy-pasteable code snippet for the most common use case (listing pods).
-- Reorganize the examples list into a linked table of contents so readers can jump directly to the category they need (Configuration, Basics, Streaming, Advanced).
-- Add a "Requirements" section stating supported Java and Kubernetes versions up front, before installation instructions.
-- Include a short "Getting Help" section linking to issues, discussions, and any community Slack/Discord channel.
-- Add badges for build status, latest release version, and license near the top for quicker at-a-glance project health checks.
+| Priority | Item | Owner | Effort |
+|----------|------|-------|--------|
+| Must have | Add a top-level "Quick Start" section with a minimal copy-pasteable code snippet for the most common use case (listing pods). | TBD | S |
+| Must have | Add a "Requirements" section stating supported Java and Kubernetes versions up front, before installation instructions. | TBD | S |
+| Nice to have | Reorganize the examples list into a linked table of contents so readers can jump directly to the category they need (Configuration, Basics, Streaming, Advanced). | TBD | M |
+| Nice to have | Include a short "Getting Help" section linking to issues, discussions, and any community Slack/Discord channel. | TBD | S |
+| Nice to have | Add badges for build status, latest release version, and license near the top for quicker at-a-glance project health checks. | TBD | S |

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,7 @@
+# README Improvement Plan
+
+- Add a top-level "Quick Start" section with a minimal copy-pasteable code snippet for the most common use case (listing pods).
+- Reorganize the examples list into a linked table of contents so readers can jump directly to the category they need (Configuration, Basics, Streaming, Advanced).
+- Add a "Requirements" section stating supported Java and Kubernetes versions up front, before installation instructions.
+- Include a short "Getting Help" section linking to issues, discussions, and any community Slack/Discord channel.
+- Add badges for build status, latest release version, and license near the top for quicker at-a-glance project health checks.


### PR DESCRIPTION
## Summary
- Adds `Plan.md`, a short original implementation plan outlining concrete steps to improve the project's README (quick start section, reorganized examples ToC, requirements section, getting-help section, and badges).

This is a documentation-only change proposing follow-up work; no existing files are modified.