### PR TITLE
docs: add Plan.md with an implementation plan for improving the README

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,7 @@
+# Plan: Improve the README
+
+- Add a "Quick Start" section near the top with the minimal steps to list pods, so new users see value before reading installation details.
+- Consolidate the three install methods (Maven, Gradle, source build) into a single collapsible/tabbed section to reduce scroll length.
+- Update the compatibility table to include the most recent Kubernetes versions and link to a CHANGELOG entry per client version.
+- Add a "Getting Help" section linking to Slack/GitHub Discussions and issue templates.
+- Include a table of contents at the top, since the file is long and currently has no in-page navigation.


### PR DESCRIPTION
## Summary
Adds a new `Plan.md` file outlining a short, original implementation plan for improving the project's `README.md` (quick start section, consolidating install instructions, updated compatibility table, getting-help section, table of contents).

## Test plan
- N/A — documentation-only change, no build/test impact