### PR TITLE
docs: add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-Small commits, steady hands — code ships as trust compounds into deploys.
+Small commits, steady hands — trust compounds, one deploy at a time.

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Small commits, steady hands — code ships as trust compounds into deploys.


### PR DESCRIPTION
## Summary
- Appends a single new line to `README.md` containing a short, original one-line poem about software delivery.

## Test plan
- N/A (documentation-only change; visually verify the new line renders correctly on GitHub).