### PR TITLE
docs: add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Code flows like rivers, from commit to release, delivering quietly, bringing users peace.

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-Code flows like rivers, from commit to release, delivering quietly, bringing users peace.
+Code flows like rivers, from commit to release — shipping quietly, bringing users peace.


### PR DESCRIPTION
This PR appends a single, original one-line poem about software delivery to the end of `README.md`.

**Changes:**
- Added one line to `README.md`: "Code flows like rivers, from commit to release, delivering quietly, bringing users peace."

No functional changes — documentation only.