### PR TITLE
docs: add one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-We ship the code, we ship it small and fast, then ship again to make it last.
+We ship the code, we ship it fast, we ship again to make it last.

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+We ship the code, we ship it small and fast, then ship again to make it last.


### PR DESCRIPTION
## Summary
- Appends a short, original one-line poem about software delivery to the end of README.md.

## Test plan
- N/A — documentation-only change, no build/test impact.