### PR TITLE
docs: add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Code is committed straight to master, tests are green, delivery flows on.


### PR DESCRIPTION
## Summary
- Adds a short, original one-line poem about software delivery to the end of `README.md`.

## Test plan
- N/A — documentation-only change, no build/test impact.