### PR TITLE
docs: add software delivery poem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+Code flows like water, shipped with care — delivery turns ideas into something everywhere.


### PR DESCRIPTION
Adds a single, original one-line poem about software delivery to the end of `README.md`.

## Changes
- Appended one new line to `README.md` with a short original poem about software delivery.

No other content was modified.