### PR TITLE
Add a one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Code ships in silence, then the pipeline sings it home.

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-Code ships in silence, then the pipeline sings it home.
+_Code ships in silence, then the pipeline carries it home._


### PR DESCRIPTION
This PR adds a short, original one-line poem about software delivery to the end of `README.md`.

**Change:**
- Appended one line to `README.md`: "Code ships in silence, then the pipeline sings it home."

No other content was modified.