### PR TITLE
docs: add one-line poem about software delivery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
+
+Code ships like quiet rivers—small commits carving paths to production.

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ ${GEN_ROOT}/gen/openapi/java.sh kubernetes ./settings
 This should run through a long-ish build process involving `docker` and eventually result in a new set of
 generated code in the `kubernetes` directory.
 
-Code ships like quiet rivers—small commits carving paths to production.
+Code ships like quiet rivers, small commits carving paths to production.


### PR DESCRIPTION
## Summary
- Appends a short, original one-line poem about software delivery to the end of `README.md`.

## Change
```
Code ships like quiet rivers—small commits carving paths to production.
```

No functional code changes; documentation only.